### PR TITLE
Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+    - mrunalp
+    - rhatdan
+    - umohnani8
+    - haircommander
+    - saschagrunert


### PR DESCRIPTION
To use openshift bot, we need an OWNERS file to define approvers to approve PRs

Signed-off-by: Peter Hunt <pehunt@redhat.com>