### PR TITLE
Fix two home page nits

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,7 +40,9 @@
       <div class="page-header-content">
         <h1 class="project-name"><span class="sr-only">{{ site.title | default: site.github.repository_name }}</span></h1>
         <h2 class="project-tagline">{{ site.description | default: site.github.project_tagline }}</h2>
+<!-- The blog site has not had an update in 3 years, uncomment if it becomes active
         <p class="project-blog"><a href="https://medium.com/cri-o">Visit blog</a></p>
+-->
       </div>
     </section>
 

--- a/index.md
+++ b/index.md
@@ -167,7 +167,7 @@ Various CNI plugins such as Flannel, Weave and OpenShift-SDN have been tested wi
 
 ### Monitoring
 
-[conmon](https://github.com/cri-o/cri-o/tree/master/conmon) is a utility within CRI-O that is used to
+[conmon](https://github.com/containers/conmon) is a utility within CRI-O that is used to
 monitor the containers, handle logging from the container process, serve attach clients and detects Out Of Memory (OOM)
 situations.
 


### PR DESCRIPTION
We've a bad link to the conmon GitHub repo, that repairs that.  It was also
pointed out that we've not posted a blog to the medium/crio site in over two
years, this comments the link to that out.  If more blogs are added there (Yes Please!), then we can turn that back on.

Addresses: #46
Addresses: #48

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>