### PR TITLE
Added Gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+ports:
+  - port: 4000
+    onOpen: open-preview
+tasks:
+  - init: |
+      script/bootstrap
+      script/server

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
+gem "kramdown-parser-gfm"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cri-o.io web site source
 
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/cri-o/cri-o.io)
+
 ## Link
 
 https://cri-o.github.io/cri-o.io/


### PR DESCRIPTION
Hi cri-o team! 👋

here is a PR that fully-automates the dev setup of cri-o/cri-o.io with Gitpod, providing anyone with a pre-built, browser-based development environment in one click:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/cri-o/cri-o.io)

<img width="1377" alt="Screen Shot 2021-05-04 at 18 01 53" src="https://user-images.githubusercontent.com/377752/117033767-fe204680-ad02-11eb-918c-e6ea0d42fc74.png">

### What it does

* Comes with all cri-o.io lifecycle dependencies pre-installed (Jekyll, Ruby, Markdown, HTML, CSS...)
* Runs the Jekyll server in a terminal and a preview browser to enable fast turnarounds and to allows to easily edit & rebuild the code

I hope this can make life easier for contributors, and for maintainers who need to review many PRs (hint: you can already open this PR in Gitpod to easily review & test it without messing up your local checkout).

I'm looking forward to your feedback on this PR! 🚀

Signed-off-by: Jan Koehnlein <jan@gitpod.io>